### PR TITLE
refactor: The ssr Property

### DIFF
--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -3,7 +3,7 @@ export default {
    ** Nuxt rendering mode
    ** See https://nuxtjs.org/api/configuration-mode
    */
-  mode: 'universal',
+  ssr: true,
   /*
    ** Nuxt target
    ** See https://nuxtjs.org/api/configuration-target


### PR DESCRIPTION
`mode` property change to `ssr` because mode option is deprecated.

`ssr: false // for SPA's`